### PR TITLE
Added three new methods for limit and pagination when getting Friends(accepted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $user->getAllFriends();
 ```php
 $user->getFriendsLimited($limit);
 ```
-#Use Case
+#### Use Case
 ```php
 $user->getFriendsLimited(5);
 ```
@@ -110,7 +110,7 @@ This will return only 5 friends.
 $user->getFriendsWithPagination($perPage);
 ```
 
-#Use Case
+#### Use Case
 ```php
 $friends = $user->getFriendsWithPagination(5);
 ```
@@ -119,7 +119,7 @@ This will return a paginator object. To render links
 5.1: Use ->render();
 5.2: Use ->links();
 ```
-#View
+####View
 ```html
 @foreach($friends as $friend)
 	<p>{{ $friend->name }}</p>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $user->getAllFriends();
 ```php
 $user->getFriendsLimited($limit);
 ```
-#### Use Case
+##### Use Case
 ```php
 $user->getFriendsLimited(5);
 ```
@@ -110,7 +110,7 @@ This will return only 5 friends.
 $user->getFriendsWithPagination($perPage);
 ```
 
-#### Use Case
+##### Use Case
 ```php
 $friends = $user->getFriendsWithPagination(5);
 ```
@@ -119,7 +119,7 @@ This will return a paginator object. To render links
 5.1: Use ->render();
 5.2: Use ->links();
 ```
-####View
+##### View
 ```html
 @foreach($friends as $friend)
 	<p>{{ $friend->name }}</p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Laravel 5 Friendships [![Build Status](https://travis-ci.org/hootlex/laravel-friendships.svg?branch=master)](https://travis-ci.org/hootlex/laravel-friendships) [![Version](https://img.shields.io/packagist/v/hootlex/laravel-friendships.svg?style=flat)](https://packagist.org/packages/hootlex/laravel-friendships)  [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE)
 
-> ** Note: getFriends() is now getAllFriends()
-
 This package gives Eloqent models the ability to manage their friendships.
 You can easily design a Facebook like Friend System.
 
@@ -96,9 +94,10 @@ $user->isBlockedBy($recipient);
 $user->getAllFriends();
 ```
 
-### Get Friends(accepted) with Limit 
+#### Get Friends(accepted) with Limit 
 ```php
 $user->getFriendsLimited($limit);
+Default $limit = 0, will return all friends
 ```
 ##### Use Case
 ```php
@@ -106,9 +105,10 @@ $user->getFriendsLimited(5);
 ```
 This will return only 5 friends.
 
-### Get Friends(accepted) with Pagination 
+#### Get Friends(accepted) with Pagination 
 ```php
 $user->getFriendsWithPagination($perPage);
+Default $perPage = 0, will return all friends
 ```
 
 ##### Use Case
@@ -117,8 +117,8 @@ $friends = $user->getFriendsWithPagination(5);
 ```
 This will return a paginator object. To render links
 ```
-5.1: Use ->render();
-5.2: Use ->links();
+Laravel >5.0: Use ->render();
+Laravel >5.2: Use ->links();
 ```
 ##### View
 ```html

--- a/README.md
+++ b/README.md
@@ -90,9 +90,40 @@ $user->hasBlocked($recipient);
 $user->isBlockedBy($recipient);
 ```
 
-#### Get Friends (It returns a collection of friend models not friendships, for example User)
+#### Get All Friends(accepted) (It returns a collection of friend models not friendships, for example User)
 ```php
-$user->getFriends();
+$user->getAllFriends();
+```
+
+### Get Friends(accepted) with Limit 
+```php
+$user->getFriendsLimited($limit);
+```
+Use Case
+```php
+$user->getFriendsLimited(5);
+```
+This will return only 5 friends.
+
+### Get Friends(accepted) with Pagination 
+```php
+$user->getFriendsWithPagination($perPage);
+```
+
+Use Case
+```php
+$friends = $user->getFriendsWithPagination(5);
+```
+This will return a paginator object. To render links
+5.1: Use ->render();
+5.2: Use ->links();
+
+View
+```html
+@foreach($friends as $friend)
+	<p>{{ $friend->name }}</p>
+@endforeach
+{!! $friends->links() !!}
 ```
 
 #### Get a single friendship

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Laravel 5 Friendships [![Build Status](https://travis-ci.org/hootlex/laravel-friendships.svg?branch=master)](https://travis-ci.org/hootlex/laravel-friendships) [![Version](https://img.shields.io/packagist/v/hootlex/laravel-friendships.svg?style=flat)](https://packagist.org/packages/hootlex/laravel-friendships)  [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE)
 
+> ** Note: getFriends() is now getAllFriends()
 
 This package gives Eloqent models the ability to manage their friendships.
 You can easily design a Facebook like Friend System.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $user->getAllFriends();
 ```php
 $user->getFriendsLimited($limit);
 ```
-Use Case
+#Use Case
 ```php
 $user->getFriendsLimited(5);
 ```
@@ -110,19 +110,21 @@ This will return only 5 friends.
 $user->getFriendsWithPagination($perPage);
 ```
 
-Use Case
+#Use Case
 ```php
 $friends = $user->getFriendsWithPagination(5);
 ```
 This will return a paginator object. To render links
+```
 5.1: Use ->render();
 5.2: Use ->links();
-
-View
+```
+#View
 ```html
 @foreach($friends as $friend)
 	<p>{{ $friend->name }}</p>
 @endforeach
+
 {!! $friends->links() !!}
 ```
 

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -189,7 +189,7 @@ trait Friendable
      *
      * @return mixed
      */
-    private function getFriends()
+    private function getFriendsQueryBuilder()
     {
         $friendships = $this->findFriendships(Status::ACCEPTED)->get(['sender_id', 'recipient_id']);
         $recipients = $friendships->lists('recipient_id')->all();
@@ -203,9 +203,9 @@ trait Friendable
      *
      * @return mixed
      */
-    public function getAllFriends()
+    public function getFriends()
     {
-       return $this->getFriends()->get();
+        return $this->getFriendsQueryBuilder()->get();
     }
 
     /**
@@ -214,13 +214,11 @@ trait Friendable
      * @param $limit
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getFriendsLimited($limit)
+    public function getFriendsLimited($limit = 0)
     {
-        if (is_numeric($limit) && $limit > 0) {
-            return $this->getFriends()->take($limit)->get();
-        } else {
-            return $this->getAllFriends();
-        }
+        if ($limit == 0) return $this->getFriends();
+
+        return $this->getFriendsQueryBuilder()->take($limit)->get();
     }
 
     /**
@@ -229,13 +227,11 @@ trait Friendable
      * @param $perPage
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getFriendsWithPagination($perPage)
+    public function getFriendsWithPagination($perPage = 0)
     {
-        if (is_numeric($perPage) && $perPage > 0) {
-            return $this->getFriends()->paginate($perPage);
-        } else {
-            return $this->getAllFriends();
-        }
+        if ($perPage == 0) return $this->getAllFriends();
+
+        return $this->getFriendsQueryBuilder()->paginate($perPage);
     }
 
     /**

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -229,7 +229,7 @@ trait Friendable
      */
     public function getFriendsWithPagination($perPage = 0)
     {
-        if ($perPage == 0) return $this->getAllFriends();
+        if ($perPage == 0) return $this->getFriends();
 
         return $this->getFriendsQueryBuilder()->paginate($perPage);
     }

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -184,18 +184,58 @@ trait Friendable
     }
 
     /**
-     * This method will not return Friendship models
+     *  This method will not return Friendship models
      * It will return the 'friends' models. ex: App\User
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return mixed
      */
-    public function getFriends()
+    private function getFriends()
     {
         $friendships = $this->findFriendships(Status::ACCEPTED)->get(['sender_id', 'recipient_id']);
         $recipients = $friendships->lists('recipient_id')->all();
         $senders = $friendships->lists('sender_id')->all();
 
-        return $this->where('id', '!=', $this->getKey())->whereIn('id', array_merge($recipients, $senders))->get();
+        return $this->where('id', '!=', $this->getKey())->whereIn('id', array_merge($recipients, $senders));
+    }
+
+    /**
+     * Get All Friends
+     *
+     * @return mixed
+     */
+    public function getAllFriends()
+    {
+       return $this->getFriends()->get();
+    }
+
+    /**
+     * Get limited amount of Accepted Friends
+     *
+     * @param $limit
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getFriendsLimited($limit)
+    {
+        if (is_numeric($limit) && $limit > 0) {
+            return $this->getFriends()->take($limit)->get();
+        } else {
+            return $this->getAllFriends();
+        }
+    }
+
+    /**
+     * Get Friends with Pagination
+     *
+     * @param $perPage
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getFriendsWithPagination($perPage)
+    {
+        if (is_numeric($perPage) && $perPage > 0) {
+            return $this->getFriends()->paginate($perPage);
+        } else {
+            return $this->getAllFriends();
+        }
     }
 
     /**

--- a/tests/FriedshipsTest.php
+++ b/tests/FriedshipsTest.php
@@ -207,11 +207,11 @@ class FriedshipsTest extends TestCase
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
 
-        $this->assertCount(2, $sender->getFriends());
-        $this->assertCount(1, $recipients[1]->getFriends());
-        $this->assertCount(0, $recipients[2]->getFriends());
-        $this->assertCount(0, $recipients[3]->getFriends());
+        $this->assertCount(2, $sender->getAllFriends());
+        $this->assertCount(1, $recipients[1]->getAllFriends());
+        $this->assertCount(0, $recipients[2]->getAllFriends());
+        $this->assertCount(0, $recipients[3]->getAllFriends());
 
-        $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
+        $this->containsOnlyInstancesOf(\App\User::class, $sender->getAllFriends());
     }
 }

--- a/tests/FriedshipsTest.php
+++ b/tests/FriedshipsTest.php
@@ -207,11 +207,11 @@ class FriedshipsTest extends TestCase
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
 
-        $this->assertCount(2, $sender->getAllFriends());
-        $this->assertCount(1, $recipients[1]->getAllFriends());
-        $this->assertCount(0, $recipients[2]->getAllFriends());
-        $this->assertCount(0, $recipients[3]->getAllFriends());
+        $this->assertCount(2, $sender->getFriends());
+        $this->assertCount(1, $recipients[1]->getFriends());
+        $this->assertCount(0, $recipients[2]->getFriends());
+        $this->assertCount(0, $recipients[3]->getFriends());
 
-        $this->containsOnlyInstancesOf(\App\User::class, $sender->getAllFriends());
+        $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }
 }


### PR DESCRIPTION
#### Get All Friends(accepted) (It returns a collection of friend models not friendships, for example User)
```php
$user->getAllFriends();
```

### Get Friends(accepted) with Limit 
```php
$user->getFriendsLimited($limit);
```
##### Use Case
```php
$user->getFriendsLimited(5);
```
This will return only 5 friends.

### Get Friends(accepted) with Pagination 
```php
$user->getFriendsWithPagination($perPage);
```

##### Use Case
```php
$friends = $user->getFriendsWithPagination(5);
```
This will return a paginator object. To render links
```
5.1: Use ->render();
5.2: Use ->links();
```
##### View
```html
@foreach($friends as $friend)
	<p>{{ $friend->name }}</p>
@endforeach

{!! $friends->links() !!}
```