### PR TITLE
Add user's personal groups (acquaintances, family, etс.) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor
+/.idea
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
 
 script:
 - cp src/database/migrations/create_friendships_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053825_create_friendships_table.php
-- cp src/database/migrations/create_friend_friendship_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friend_friendship_groups_table.php
-- cp src/config/friendships.php vendor/laravel/laravel/config/friendships.php
+- yes | cp src/database/migrations/create_friend_friendship_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friend_friendship_groups_table.php
+- yes | cp tests/config/friendships.php vendor/laravel/laravel/config/friendships.php
 - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
 - cd vendor/laravel/laravel
 - composer install --dev --prefer-source --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 script:
 - cp src/database/migrations/create_friendships_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053825_create_friendships_table.php
-- yes | cp src/database/migrations/create_friend_friendship_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friend_friendship_groups_table.php
+- yes | cp src/database/migrations/create_friendships_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friendships_groups_table.php
 - yes | cp tests/config/friendships.php vendor/laravel/laravel/config/friendships.php
 - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
 - cd vendor/laravel/laravel

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
 
 script:
 - cp src/database/migrations/create_friendships_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053825_create_friendships_table.php
+- cp src/database/migrations/create_friend_friendship_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friend_friendship_groups_table.php
+- cp src/config/friendships.php vendor/laravel/laravel/config/friendships.php
 - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
 - cd vendor/laravel/laravel
 - composer install --dev --prefer-source --no-interaction

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can easily design a Facebook like Friend System.
 - Accept Friend Requests
 - Deny Friend Requests
 - Block Another Model
+- Group user Friends to personal groups (defined in config): family, best friends, acquaintances
 
 ## Installation
 
@@ -60,6 +61,21 @@ $user->acceptFriendRequest($recipient);
 $user->denyFriendRequest($recipient);
 ```
 
+#### Group a Friend
+```php
+$user->groupFriend($friend, $group_name);
+```
+
+#### Remove a Friend from family group
+```php
+$user->ungroupFriend($friend, 'family');
+```
+
+#### Remove a Friend from all groups
+```php
+$user->ungroupFriend($friend);
+```
+
 #### Remove Friend
 ```php
 $user->unfriend($recipient);
@@ -105,6 +121,10 @@ $user->getFriendship($recipient);
 $user->getAllFriendships();
 ```
 
+#### Get a list of all Friendships in specific group
+```php
+$user->getAllFriendships($group_name);
+
 #### Get a list of pending Friendships
 ```php
 $user->getPendingFriendships();
@@ -113,6 +133,11 @@ $user->getPendingFriendships();
 #### Get a list of accepted Friendships
 ```php
 $user->getAcceptedFriendships();
+```
+
+#### Get a list of accepted Friendships in specific group
+```php
+$user->getAcceptedFriendships($group_name);
 ```
 
 #### Get a list of denied Friendships
@@ -135,6 +160,10 @@ $user->getFriendRequests();
 $user->getFriendsCount();
 ```
 
+#### Get the number of Friends in specific group
+```php
+$user->getFriendsCount($group_name);
+```
 
 ### To get a collection of friend models (ex. User) use the following methods:
 #### Get Friends
@@ -142,9 +171,14 @@ $user->getFriendsCount();
 $user->getFriends();
 ```
 
+#### Collection of Friends in specific group paginated:
+```php
+$user->getFriends($group_name, $perPage = 20);
+```
+
 #### Get Friends Paginated
 ```php
-$user->getFriends($perPage = 20);
+$user->getFriends('', $perPage = 20);
 ```
 
 #### Get Friends of Friends

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ $user->getAllFriendships();
 #### Get a list of all Friendships in specific group
 ```php
 $user->getAllFriendships($group_name);
+```
 
 #### Get a list of pending Friendships
 ```php

--- a/README.md
+++ b/README.md
@@ -28,11 +28,20 @@ Then include the service provider inside `config/app.php`.
     ...
 ];
 ```
-Lastly you need to publish the migration and migrate the database
+Publish config and migrations
 
 ```
-php artisan vendor:publish --provider="Hootlex\Friendships\FriendshipsServiceProvider" && php artisan migrate
+php artisan vendor:publish --provider="Hootlex\Friendships\FriendshipsServiceProvider"
 ```
+Configure the published config in
+```
+config\friendships.php
+```
+Finally, migrate the database
+```
+php artisan migrate
+```
+
 ## Setup a Model
 ```php
 use Hootlex\Friendships\Traits\Friendable;

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ $user->getFriends();
 
 #### Collection of Friends in specific group paginated:
 ```php
-$user->getFriends($group_name, $perPage = 20);
+$user->getFriends($perPage = 20, $group_name);
 ```
 
 #### Get Friends Paginated
 ```php
-$user->getFriends('', $perPage = 20);
+$user->getFriends($perPage = 20);
 ```
 
 #### Get Friends of Friends

--- a/src/FriendshipsServiceProvider.php
+++ b/src/FriendshipsServiceProvider.php
@@ -14,8 +14,6 @@ class FriendshipsServiceProvider extends ServiceProvider
     public function boot()
     {
 
-        $config = include __DIR__.'/config/friendships.php';
-
         if (class_exists('CreateFriendshipsTable') || class_exists('CreateFriendshipsGroupsTable')) {
             return;
         }
@@ -23,14 +21,10 @@ class FriendshipsServiceProvider extends ServiceProvider
         $stub      = __DIR__.'/database/migrations/';
         $target    = database_path('migrations').'/';
 
-        $migrations = [];
-        $migrations[$stub.'create_friendships_table.php'] = $target.date('Y_m_d_His', time()).'_create_friendships_table.php';
-
-        if (isset($config['groups']) && !empty($config['groups'])) {
-            $migrations[$stub.'create_friendships_groups_table.php'] = $target.date('Y_m_d_His', time()+1).'_create_friendships_groups_table.php';
-        }
-
-        $this->publishes($migrations, 'migrations');
+        $this->publishes([
+            $stub.'create_friendships_table.php'        => $target.date('Y_m_d_His', time()).'_create_friendships_table.php',
+            $stub.'create_friendships_groups_table.php' => $target.date('Y_m_d_His', time()+1).'_create_friendships_groups_table.php'
+        ], 'migrations');
 
         $this->publishes([
             __DIR__.'/config/friendships.php' => config_path('friendships.php'),

--- a/src/FriendshipsServiceProvider.php
+++ b/src/FriendshipsServiceProvider.php
@@ -13,14 +13,17 @@ class FriendshipsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (class_exists('CreateFriendshipsTable')) {
+        if (class_exists('CreateFriendshipsTable') || class_exists('CreateFriendFriendshipGroupsTable')) {
             return;
         }
 
-        $timestamp = date('Y_m_d_His', time());
-        $stub      = __DIR__.'/database/migrations/create_friendships_table.php';
-        $target    = database_path('migrations').'/'.$timestamp.'_create_friendships_table.php';
-        $this->publishes([$stub => $target], 'migrations');
+        $stub      = __DIR__.'/database/migrations/';
+        $target    = database_path('migrations').'/';
+        $this->publishes([
+            $stub.'create_friendships_table.php'              => $target.date('Y_m_d_His', time()).'_create_friendships_table.php',
+            $stub.'create_friend_friendship_groups_table.php' => $target.date('Y_m_d_His', time()+1).'_create_friend_friendship_groups_table.php',
+
+        ], 'migrations');
         $this->publishes([
             __DIR__.'/config/friendships.php' => config_path('friendships.php'),
         ], 'config');

--- a/src/FriendshipsServiceProvider.php
+++ b/src/FriendshipsServiceProvider.php
@@ -18,11 +18,14 @@ class FriendshipsServiceProvider extends ServiceProvider
         }
 
         $timestamp = date('Y_m_d_His', time());
-        $stub = __DIR__.'/database/migrations/create_friendships_table.php';
-        $target = database_path('migrations').'/'.$timestamp.'_create_friendships_table.php';
+        $stub      = __DIR__.'/database/migrations/create_friendships_table.php';
+        $target    = database_path('migrations').'/'.$timestamp.'_create_friendships_table.php';
         $this->publishes([$stub => $target], 'migrations');
+        $this->publishes([
+            __DIR__.'/config/friendships.php' => config_path('friendships.php'),
+        ], 'config');
     }
-    
+
     /**
      * Register any application services.
      *

--- a/src/FriendshipsServiceProvider.php
+++ b/src/FriendshipsServiceProvider.php
@@ -16,7 +16,7 @@ class FriendshipsServiceProvider extends ServiceProvider
 
         $config = include __DIR__.'/config/friendships.php';
 
-        if (class_exists('CreateFriendshipsTable') || class_exists('CreateFriendFriendshipGroupsTable')) {
+        if (class_exists('CreateFriendshipsTable') || class_exists('CreateFriendshipsGroupsTable')) {
             return;
         }
 
@@ -27,7 +27,7 @@ class FriendshipsServiceProvider extends ServiceProvider
         $migrations[$stub.'create_friendships_table.php'] = $target.date('Y_m_d_His', time()).'_create_friendships_table.php';
 
         if (isset($config['groups']) && !empty($config['groups'])) {
-            $migrations[$stub.'create_friend_friendship_groups_table.php'] = $target.date('Y_m_d_His', time()+1).'_create_friend_friendship_groups_table.php';
+            $migrations[$stub.'create_friendships_groups_table.php'] = $target.date('Y_m_d_His', time()+1).'_create_friendships_groups_table.php';
         }
 
         $this->publishes($migrations, 'migrations');

--- a/src/FriendshipsServiceProvider.php
+++ b/src/FriendshipsServiceProvider.php
@@ -13,20 +13,29 @@ class FriendshipsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+
+        $config = include __DIR__.'/config/friendships.php';
+
         if (class_exists('CreateFriendshipsTable') || class_exists('CreateFriendFriendshipGroupsTable')) {
             return;
         }
 
         $stub      = __DIR__.'/database/migrations/';
         $target    = database_path('migrations').'/';
-        $this->publishes([
-            $stub.'create_friendships_table.php'              => $target.date('Y_m_d_His', time()).'_create_friendships_table.php',
-            $stub.'create_friend_friendship_groups_table.php' => $target.date('Y_m_d_His', time()+1).'_create_friend_friendship_groups_table.php',
 
-        ], 'migrations');
+        $migrations = [];
+        $migrations[$stub.'create_friendships_table.php'] = $target.date('Y_m_d_His', time()).'_create_friendships_table.php';
+
+        if (isset($config['groups']) && !empty($config['groups'])) {
+            $migrations[$stub.'create_friend_friendship_groups_table.php'] = $target.date('Y_m_d_His', time()+1).'_create_friend_friendship_groups_table.php';
+        }
+
+        $this->publishes($migrations, 'migrations');
+
         $this->publishes([
             __DIR__.'/config/friendships.php' => config_path('friendships.php'),
         ], 'config');
+
     }
 
     /**

--- a/src/Models/FriendFriendshipGroups.php
+++ b/src/Models/FriendFriendshipGroups.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Hootlex\Friendships\Models;
+
+use Hootlex\Friendships\Status;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class FriendFriendshipGroups
+ * @package Hootlex\Friendships\Models
+ */
+class FriendFriendshipGroups extends Model
+{
+
+    /**
+     * @var array
+     */
+    protected $fillable = ['friendship_id', 'group_id', 'friend_id', 'friend_type'];
+
+    /**
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = array())
+    {
+        $this->table = config('friendships.tables.fr_groups_pivot');
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function friendship() {
+        return $this->belongsTo('Friendship', 'friendship_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function friend() {
+        return $this->morphTo('friend');
+    }
+
+
+}

--- a/src/Models/Friendship.php
+++ b/src/Models/Friendship.php
@@ -7,15 +7,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class Friendship extends Model
 {
-    /**
-     * @var string
-     */
-    public $table = 'friendships';
 
     /**
      * @var array
      */
     protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = array())
+    {
+        $this->table = config('friendships.tables.fr_pivot');
+
+        parent::__construct($attributes);
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo

--- a/src/Models/Friendship.php
+++ b/src/Models/Friendship.php
@@ -108,7 +108,7 @@ class Friendship extends Model
                         $query->where($groups_pvt_tbl . '.friend_id', '!=', $model->getKey())
                             ->where($groups_pvt_tbl . '.friend_type', '=', $model->getMorphClass());
                     })
-                    ->orWhere($groups_pvt_tbl . '.friend_type', '!=', $model->getMorphClass());;
+                    ->orWhere($groups_pvt_tbl . '.friend_type', '!=', $model->getMorphClass());
             });
 
         }

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -412,7 +412,7 @@ trait Friendable
                                   $q->whereIn('recipient_id', $friendIds);
                               });
                           })
-                          ->whereGroup($group_slug)
+                          ->whereGroup($this, $group_slug)
                           ->get(['sender_id', 'recipient_id']);
 
         $fofIds = array_unique(

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -3,9 +3,14 @@
 namespace Hootlex\Friendships\Traits;
 
 use Hootlex\Friendships\Models\Friendship;
+use Hootlex\Friendships\Models\FriendFriendshipGroups;
 use Hootlex\Friendships\Status;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Class Friendable
+ * @package Hootlex\Friendships\Traits
+ */
 trait Friendable
 {
     /**
@@ -15,6 +20,7 @@ trait Friendable
      */
     public function befriend(Model $recipient)
     {
+
         if (!$this->canBefriend($recipient)) {
             return false;
         }
@@ -84,6 +90,62 @@ trait Friendable
         ]);
     }
 
+
+    /**
+     * @param Model $friend
+     * @param $group_slug
+     * @return bool
+     */
+    public function groupFriend(Model $friend, $group_slug)
+    {
+
+        $friendship       = $this->findFriendship($friend)->whereStatus(Status::ACCEPTED)->first();
+        $groups_available = config('friendships.groups', []);
+
+        if (!isset($groups_available[$group_slug]) || empty($friendship))
+            return false;
+
+        $group = $friendship->groups()->firstOrCreate([
+            'friendship_id' => $friendship->id,
+            'group_id'      => $groups_available[$group_slug],
+            'friend_id'     => $friend->getKey(),
+            'friend_type'   => $friend->getMorphClass(),
+        ]);
+
+        return $group->wasRecentlyCreated;
+
+    }
+
+    /**
+     * @param Model $friend
+     * @param $group_slug
+     * @return bool
+     */
+    public function ungroupFriend(Model $friend, $group_slug = '')
+    {
+
+        $friendship       = $this->findFriendship($friend)->first();
+        $groups_available = config('friendships.groups', []);
+
+        if (empty($friendship))
+            return false;
+
+        $where = [
+            'friendship_id' => $friendship->id,
+            'friend_id'     => $friend->getKey(),
+            'friend_type'   => $friend->getMorphClass(),
+        ];
+
+        if ('' !== $group_slug && isset($groups_available[$group_slug])) {
+            $where['group_id'] = $groups_available[$group_slug];
+        }
+
+        $result = $friendship->groups()->where($where)->delete();
+
+        return $result;
+
+    }
+
     /**
      * @param Model $recipient
      *
@@ -123,27 +185,35 @@ trait Friendable
 
     /**
      * @return \Illuminate\Database\Eloquent\Collection
+     *
+     * @param string $group_slug
+     *
      */
-    public function getAllFriendships()
+    public function getAllFriendships($group_slug = '')
     {
-        return $this->findFriendships()->get();
+        return $this->findFriendships(null, $group_slug)->get();
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Collection
      *
+     * @param string $group_slug
+     *
      */
-    public function getPendingFriendships()
+    public function getPendingFriendships($group_slug = '')
     {
-        return $this->findFriendships(Status::PENDING)->get();
+        return $this->findFriendships(Status::PENDING, $group_slug)->get();
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Collection
+     *
+     * @param string $group_slug
+     *
      */
-    public function getAcceptedFriendships()
+    public function getAcceptedFriendships($group_slug = '')
     {
-        return $this->findFriendships(Status::ACCEPTED)->get();
+        return $this->findFriendships(Status::ACCEPTED, $group_slug)->get();
     }
 
     /**
@@ -196,16 +266,17 @@ trait Friendable
      * This method will not return Friendship models
      * It will return the 'friends' models. ex: App\User
      *
+     * @param string $group_slug
      * @param int $perPage Number
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getFriends($perPage = 0)
+    public function getFriends($group_slug = '', $perPage = 0)
     {
         if ($perPage == 0) {
-            return $this->getFriendsQueryBuilder()->get();
+            return $this->getFriendsQueryBuilder($group_slug)->get();
         } else {
-            return $this->getFriendsQueryBuilder()->paginate($perPage);
+            return $this->getFriendsQueryBuilder($group_slug)->paginate($perPage);
         }
     }
 
@@ -230,11 +301,13 @@ trait Friendable
     /**
      * Get the number of friends
      *
+     * @param string $group_slug
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getFriendsCount()
+    public function getFriendsCount($group_slug = '')
     {
-        $friendsCount = $this->findFriendships(Status::ACCEPTED)->count();
+        $friendsCount = $this->findFriendships(Status::ACCEPTED, $group_slug)->count();
         return $friendsCount;
     }
 
@@ -251,6 +324,7 @@ trait Friendable
             $this->unblockFriend($recipient);
             return true;
         }
+
         // if sender has a friendship with the recipient return false
         if ($friendship = $this->getFriendship($recipient)) {
             // if previous friendship was Denied then let the user send fr
@@ -273,18 +347,20 @@ trait Friendable
 
     /**
      * @param $status
+     * @param string $group_slug
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    private function findFriendships($status = null)
+    private function findFriendships($status = null, $group_slug = '')
     {
+
         $query = Friendship::where(function ($query) {
-                $query->where(function ($q) {
-                    $q->whereSender($this);
-                })->orWhere(function ($q) {
-                    $q->whereRecipient($this);
-                });
+            $query->where(function ($q) {
+                $q->whereSender($this);
+            })->orWhere(function ($q) {
+                $q->whereRecipient($this);
             });
+        })->whereGroup($this, $group_slug);
 
         //if $status is passed, add where clause
         if(!is_null($status)){
@@ -294,17 +370,20 @@ trait Friendable
         return $query;
     }
 
-
     /**
      * Get the query builder of the 'friend' model
      *
+     * @param string $group_slug
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    private function getFriendsQueryBuilder()
+    private function getFriendsQueryBuilder($group_slug = '')
     {
-        $friendships = $this->findFriendships(Status::ACCEPTED)->get(['sender_id', 'recipient_id']);
-        $recipients = $friendships->lists('recipient_id')->all();
-        $senders = $friendships->lists('sender_id')->all();
+        $fr_fields        = ['sender_id', 'recipient_id'];
+
+        $friendships = $this->findFriendships(Status::ACCEPTED, $group_slug)->get(['sender_id', 'recipient_id']);
+        $recipients  = $friendships->lists('recipient_id')->all();
+        $senders     = $friendships->lists('sender_id')->all();
 
         return $this->where('id', '!=', $this->getKey())->whereIn('id', array_merge($recipients, $senders));
     }
@@ -312,9 +391,11 @@ trait Friendable
     /**
      * Get the query builder for friendsOfFriends ('friend' model)
      *
+     * @param string $group_slug
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    private function friendsOfFriendsQueryBuilder()
+    private function friendsOfFriendsQueryBuilder($group_slug = '')
     {
         $friendships = $this->findFriendships(Status::ACCEPTED)->get(['sender_id', 'recipient_id']);
         $recipients = $friendships->lists('recipient_id')->all();
@@ -330,7 +411,9 @@ trait Friendable
                               })->orWhere(function ($q) use ($friendIds) {
                                   $q->whereIn('recipient_id', $friendIds);
                               });
-                          })->get(['sender_id', 'recipient_id']);
+                          })
+                          ->whereGroup($group_slug)
+                          ->get(['sender_id', 'recipient_id']);
 
         $fofIds = array_unique(
             array_merge($fofs->pluck('sender_id')->all(), $fofs->lists('recipient_id')->all())
@@ -353,6 +436,14 @@ trait Friendable
     public function friends()
     {
         return $this->morphMany(Friendship::class, 'sender');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function groups()
+    {
+        return $this->morphMany(FriendFriendshipGroups::class, 'friend');
     }
 
 }

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -266,12 +266,12 @@ trait Friendable
      * This method will not return Friendship models
      * It will return the 'friends' models. ex: App\User
      *
-     * @param string $group_slug
      * @param int $perPage Number
+     * @param string $group_slug
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getFriends($group_slug = '', $perPage = 0)
+    public function getFriends($perPage = 0, $group_slug = '')
     {
         if ($perPage == 0) {
             return $this->getFriendsQueryBuilder($group_slug)->get();

--- a/src/config/friendships.php
+++ b/src/config/friendships.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+
+    'tables' => [
+        'fr_pivot' => 'friendships',
+        'fr_groups_pivot' => 'user_friendship_groups'
+    ],
+
+    'groups' => [
+        'close_friend' => 0,
+    ]
+
+];

--- a/src/config/friendships.php
+++ b/src/config/friendships.php
@@ -9,8 +9,8 @@ return [
 
     'groups' => [
         'acquaintances' => 0,
-        //'close_friends' => 1,
-        //'family' => 2
+        'close_friends' => 1,
+        'family' => 2
     ]
 
 ];

--- a/src/config/friendships.php
+++ b/src/config/friendships.php
@@ -8,7 +8,9 @@ return [
     ],
 
     'groups' => [
-        'close_friend' => 0,
+        //'acquaintances' => 0,
+        //'close_friends' => 1,
+        //'family' => 2
     ]
 
 ];

--- a/src/config/friendships.php
+++ b/src/config/friendships.php
@@ -8,7 +8,7 @@ return [
     ],
 
     'groups' => [
-        //'acquaintances' => 0,
+        'acquaintances' => 0,
         //'close_friends' => 1,
         //'family' => 2
     ]

--- a/src/database/migrations/create_friend_friendship_groups_table.php
+++ b/src/database/migrations/create_friend_friendship_groups_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Class CreateFriendFriendshipGroupsTable
+ */
+class CreateFriendFriendshipGroupsTable extends Migration
+{
+
+    public function up() {
+
+        Schema::create(config('friendships.tables.fr_groups_pivot'), function (Blueprint $table) {
+
+            $table->integer('friendship_id')->unsigned();
+            $table->morphs('friend');
+            $table->integer('group_id')->unsigned();
+
+            $table->foreign('friendship_id')
+                ->references('id')
+                ->on(config('friendships.tables.fr_pivot'))
+                ->onDelete('cascade');
+
+            $table->unique(['friendship_id', 'friend_id', 'friend_type', 'group_id'], 'unique');
+
+        });
+
+    }
+
+    public function down() {
+        Schema::dropIfExists(config('friendships.tables.fr_groups_pivot'));
+    }
+
+}

--- a/src/database/migrations/create_friendships_groups_table.php
+++ b/src/database/migrations/create_friendships_groups_table.php
@@ -4,9 +4,9 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 /**
- * Class CreateFriendFriendshipGroupsTable
+ * Class CreateFriendshipsGroupsTable
  */
-class CreateFriendFriendshipGroupsTable extends Migration
+class CreateFriendshipsGroupsTable extends Migration
 {
 
     public function up() {

--- a/src/database/migrations/create_friendships_table.php
+++ b/src/database/migrations/create_friendships_table.php
@@ -5,19 +5,21 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateFriendshipsTable extends Migration
 {
-    public function up()
-    {
-        Schema::create('friendships', function (Blueprint $table) {
+
+    public function up() {
+
+        Schema::create(config('friendships.tables.fr_pivot'), function (Blueprint $table) {
             $table->increments('id');
             $table->morphs('sender');
             $table->morphs('recipient');
             $table->tinyInteger('status')->default(0);
             $table->timestamps();
         });
+
     }
 
-    public function down()
-    {
-        Schema::dropIfExists('friendships');
+    public function down() {
+        Schema::dropIfExists(config('friendships.tables.fr_pivot'));
     }
+
 }

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+/*
+ * Test User Personal Friend Groups
+*/
+class FriendshipsGroupsTest extends TestCase
+{
+    use DatabaseTransactions;
+    
+    
+    /** @test */
+    public function user_can_add_a_friend_to_a_group()
+    {
+        
+        $sender    = createUser();
+        $recipient = createUser();
+        
+        $sender->befriend($recipient);
+        $recipient->acceptFriendRequest($sender);
+        
+        $this->assertTrue((boolean)$recipient->groupFriend($sender, 'acquaintances'));
+        $this->assertTrue((boolean)$sender->groupFriend($recipient, 'family'));
+        
+        // it only adds a friend to a group once
+        $this->assertFalse((boolean)$sender->groupFriend($recipient, 'family'));
+        
+        // expect that users have been attached to specified groups
+        $this->assertCount(1, $sender->getFriends(0, 'family'));
+        $this->assertCount(1, $recipient->getFriends(0, 'acquaintances'));
+    
+        $this->assertEquals($recipient->id, $sender->getFriends(0, 'family')->first()->id);
+        $this->assertEquals($sender->id, $recipient->getFriends(0, 'acquaintances')->first()->id);
+        
+    }
+    
+    /** @test */
+    public function user_cannot_add_a_non_friend_to_a_group()
+    {
+        $sender   = createUser();
+        $stranger = createUser();
+        
+        $this->assertFalse((boolean)$sender->groupFriend($stranger, 'family'));
+        $this->assertCount(0, $sender->getFriends(0, 'family'));
+    }
+    
+    /** @test */
+    public function user_can_remove_a_friend_from_group()
+    {
+        $sender    = createUser();
+        $recipient = createUser();
+        
+        $sender->befriend($recipient);
+        $recipient->acceptFriendRequest($sender);
+    
+        $recipient->groupFriend($sender, 'acquaintances');
+        $recipient->groupFriend($sender, 'family');
+        
+        $this->assertEquals(1, $recipient->ungroupFriend($sender, 'acquaintances'));
+        
+        $this->assertCount(0, $sender->getFriends(0, 'acquaintances'));
+        
+        // expect that friend has been removed from acquaintances but not family
+        $this->assertCount(0, $recipient->getFriends(0, 'acquaintances'));
+        $this->assertCount(0, $recipient->getFriends(1, 'family'));
+    }
+    
+    /** @test */
+    public function user_can_remove_a_friend_from_all_groups()
+    {
+        $sender    = createUser();
+        $recipient = createUser();
+        
+        $sender->befriend($recipient);
+        $recipient->acceptFriendRequest($sender);
+        
+        $sender->groupFriend($recipient, 'family');
+        $sender->groupFriend($recipient, 'acquaintances');
+    
+        $sender->ungroupFriend($recipient);
+        
+        $this->assertCount(0, $sender->getFriends(0, 'family'));
+        $this->assertCount(0, $sender->getFriends(0, 'acquaintances'));
+    }
+    
+    /** @test */
+    public function it_returns_friends_of_a_group()
+    {
+        $sender     = createUser();
+        $recipients = createUser([], 10);
+        
+        foreach ($recipients as $key => $recipient) {
+            
+            $sender->befriend($recipient);
+            $recipient->acceptFriendRequest($sender);
+            
+            if ($key % 2 === 0) {
+                $sender->groupFriend($recipient, 'family');
+            }
+            
+        }
+        
+        $this->assertCount(5, $sender->getFriends(0, 'family'));
+        $this->assertCount(10, $sender->getFriends());
+    }
+    
+    
+}

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -65,7 +65,7 @@ class FriendshipsGroupsTest extends TestCase
         
         // expect that friend has been removed from acquaintances but not family
         $this->assertCount(0, $recipient->getFriends(0, 'acquaintances'));
-        $this->assertCount(0, $recipient->getFriends(0, 'family'));
+        $this->assertCount(1, $recipient->getFriends(0, 'family'));
     }
     
     /** @test */

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -140,7 +140,7 @@ class FriendshipsGroupsTest extends TestCase
         $this->assertCount(3, $sender->getAllFriendships('acquaintances'));
         $this->assertCount(1, $sender->getAllFriendships('family'));
         $this->assertCount(0, $sender->getAllFriendships('close_friends'));
-        $this->assertCount(4, $sender->getAllFriendships('whatever'));
+        $this->assertCount(5, $sender->getAllFriendships('whatever'));
     }
 
 
@@ -179,7 +179,7 @@ class FriendshipsGroupsTest extends TestCase
 
         //Assertions
 
-        $this->assertEquals(4, $sender->getFriendsCount('acquaintances'));
+        $this->assertEquals(5, $sender->getFriendsCount('acquaintances'));
         $this->assertEquals(0, $sender->getFriendsCount('family'));
         $this->assertEquals(0, $recipient->getFriendsCount('acquaintances'));
         $this->assertEquals(0, $recipient->getFriendsCount('family'));
@@ -221,7 +221,7 @@ class FriendshipsGroupsTest extends TestCase
         $this->assertCount(4, $sender->getFriends(10, 'acquaintances'));
 
         $this->assertCount(2, $sender->getFriends(0, 'close_friends'));
-        $this->assertCount(2, $sender->getFriends(1, 'close_friends'));
+        $this->assertCount(1, $sender->getFriends(1, 'close_friends'));
 
         $this->assertCount(1, $sender->getFriends(0, 'family'));
 

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -65,7 +65,7 @@ class FriendshipsGroupsTest extends TestCase
         
         // expect that friend has been removed from acquaintances but not family
         $this->assertCount(0, $recipient->getFriends(0, 'acquaintances'));
-        $this->assertCount(0, $recipient->getFriends(1, 'family'));
+        $this->assertCount(0, $recipient->getFriends(0, 'family'));
     }
     
     /** @test */

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -388,10 +388,10 @@ class FriendshipsTest extends TestCase
                 $sender->groupFriend($recipient, 'family');
             }
 
-            $this->assertCount(5, $sender->getFriends('family'));
-            $this->assertCount(10, $sender->getFriends());
-
         }
+
+        $this->assertCount(5, $sender->getFriends('family'));
+        $this->assertCount(10, $sender->getFriends());
 
     }
 

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -311,12 +311,12 @@ class FriendshipsTest extends TestCase
         $recipients[4]->acceptFriendRequest($sender);
 
 
-        $this->assertCount(2, $sender->getFriends(2));
-        $this->assertCount(4, $sender->getFriends(0));
-        $this->assertCount(4, $sender->getFriends(10));
+        $this->assertCount(2, $sender->getFriends('', 2));
+        $this->assertCount(4, $sender->getFriends('', 0));
+        $this->assertCount(4, $sender->getFriends('', 10));
         $this->assertCount(1, $recipients[1]->getFriends());
         $this->assertCount(0, $recipients[2]->getFriends());
-        $this->assertCount(0, $recipients[5]->getFriends(2));
+        $this->assertCount(0, $recipients[5]->getFriends('', 2));
 
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -368,8 +368,8 @@ class FriendshipsTest extends TestCase
         $sender->groupFriend($recipient, 'family');
         $sender->groupFriend($recipient, 'acquaintances');
 
-        $this->assertCount(1, $recipient->ungroupFriend($sender));
-        $this->assertCount(1, $sender->ungroupFriend($recipient, 'family'));
+        $this->assertEquals(1, $recipient->ungroupFriend($sender));
+        $this->assertEquals(1, $sender->ungroupFriend($recipient, 'family'));
 
     }
 

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -311,12 +311,12 @@ class FriendshipsTest extends TestCase
         $recipients[4]->acceptFriendRequest($sender);
 
 
-        $this->assertCount(2, $sender->getFriends('', 2));
-        $this->assertCount(4, $sender->getFriends('', 0));
-        $this->assertCount(4, $sender->getFriends('', 10));
+        $this->assertCount(2, $sender->getFriends(2));
+        $this->assertCount(4, $sender->getFriends(0));
+        $this->assertCount(4, $sender->getFriends(10));
         $this->assertCount(1, $recipients[1]->getFriends());
         $this->assertCount(0, $recipients[2]->getFriends());
-        $this->assertCount(0, $recipients[5]->getFriends('', 2));
+        $this->assertCount(0, $recipients[5]->getFriends(2));
 
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -390,7 +390,7 @@ class FriendshipsTest extends TestCase
 
         }
 
-        $this->assertCount(5, $sender->getFriends('family'));
+        $this->assertCount(5, $sender->getFriends(0, 'family'));
         $this->assertCount(10, $sender->getFriends());
 
     }

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -321,6 +321,80 @@ class FriendshipsTest extends TestCase
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }
 
+    /*
+     * Test User Personal Friend Groups
+    */
+
+    /** @test */
+    public function add_friend_to_group() {
+
+        $sender    = createUser();
+        $recipient = createUser();
+        $stranger  = createUser();
+
+        $sender->befriend($recipient);
+        $recipient->acceptFriendRequest($sender);
+
+        $this->assertTrue((boolean)$recipient->groupFriend($sender, 'acquaintances'));
+        $this->assertTrue((boolean)$sender->groupFriend($recipient, 'family'));
+
+        $this->assertFalse((boolean)$sender->groupFriend($recipient, 'family'));
+        $this->assertFalse((boolean)$stranger->groupFriend($recipient, 'acquaintances'));
+
+
+    }
+
+    /** @test */
+    public function add_stranger_to_group() {
+
+        $sender    = createUser();
+        $stranger  = createUser();
+
+        $this->assertFalse((boolean)$sender->groupFriend($stranger, 'family'));
+
+    }
+
+    /** @test */
+    public function remove_friend_from_group() {
+
+        $sender    = createUser();
+        $recipient = createUser();
+
+        $sender->befriend($recipient);
+        $recipient->acceptFriendRequest($sender);
+
+        $recipient->groupFriend($sender, 'acquaintances');
+
+        $sender->groupFriend($recipient, 'family');
+        $sender->groupFriend($recipient, 'acquaintances');
+
+        $this->assertCount(1, $recipient->ungroupFriend($sender));
+        $this->assertCount(1, $sender->ungroupFriend($recipient, 'family'));
+
+    }
+
+    /** @test */
+    public function get_friends_by_group() {
+
+        $sender     = createUser();
+        $recipients = createUser([], 10);
+
+        foreach ($recipients as $key => $recipient) {
+
+            $sender->befriend($recipient);
+            $recipient->acceptFriendRequest($sender);
+
+            if ($key % 2 === 0) {
+                $sender->groupFriend($recipient, 'family');
+            }
+
+            $this->assertCount(5, $sender->getFriends('family'));
+            $this->assertCount(10, $sender->getFriends());
+
+        }
+
+    }
+
     /** @test */
     public function it_returns_user_friends_of_friends(){
         $sender = createUser();
@@ -346,4 +420,6 @@ class FriendshipsTest extends TestCase
 
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriendsOfFriends());
     }
+
+
 }

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -7,419 +7,359 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class FriendshipsTest extends TestCase
 {
     use DatabaseTransactions;
-
+    
     /** @test */
     public function user_can_send_a_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         $sender->befriend($recipient);
-
+        
         $this->assertCount(1, $recipient->getFriendRequests());
     }
-
+    
     /** @test */
     public function user_can_not_send_a_friend_request_if_frienship_is_pending()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         $sender->befriend($recipient);
         $sender->befriend($recipient);
         $sender->befriend($recipient);
-
+        
         $this->assertCount(1, $recipient->getFriendRequests());
     }
-
-
+    
+    
     /** @test */
     public function user_can_send_a_friend_request_if_frienship_is_denied()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         $sender->befriend($recipient);
         $recipient->denyFriendRequest($sender);
-
+        
         $sender->befriend($recipient);
-
+        
         $this->assertCount(1, $recipient->getFriendRequests());
     }
-
+    
     /** @test */
     public function user_is_friend_with_another_user_if_accepts_a_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         //send fr
         $sender->befriend($recipient);
         //accept fr
         $recipient->acceptFriendRequest($sender);
-
+        
         $this->assertTrue($recipient->isFriendWith($sender));
         $this->assertTrue($sender->isFriendWith($recipient));
         //fr has been delete
         $this->assertCount(0, $recipient->getFriendRequests());
     }
-
+    
     /** @test */
     public function user_is_not_friend_with_another_user_until_he_accepts_a_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         //send fr
         $sender->befriend($recipient);
-
+        
         $this->assertFalse($recipient->isFriendWith($sender));
         $this->assertFalse($sender->isFriendWith($recipient));
     }
-
+    
     /** @test */
     public function user_has_friend_request_from_another_user_if_he_received_a_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         //send fr
         $sender->befriend($recipient);
-
+        
         $this->assertTrue($recipient->hasFriendRequestFrom($sender));
         $this->assertFalse($sender->hasFriendRequestFrom($recipient));
     }
-
+    
     /** @test */
     public function user_has_not_friend_request_from_another_user_if_he_accepted_the_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         //send fr
         $sender->befriend($recipient);
         //accept fr
         $recipient->acceptFriendRequest($sender);
-
+        
         $this->assertFalse($recipient->hasFriendRequestFrom($sender));
         $this->assertFalse($sender->hasFriendRequestFrom($recipient));
     }
-
+    
     /** @test */
-    public function user_cannot_accept_his_own_friend_request(){
-        $sender = createUser();
+    public function user_cannot_accept_his_own_friend_request()
+    {
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         //send fr
         $sender->befriend($recipient);
-
+        
         $sender->acceptFriendRequest($recipient);
         $this->assertFalse($recipient->isFriendWith($sender));
     }
-
+    
     /** @test */
     public function user_can_deny_a_friend_request()
     {
-        $sender = createUser();
+        $sender    = createUser();
         $recipient = createUser();
         $sender->befriend($recipient);
-
+        
         $recipient->denyFriendRequest($sender);
-
+        
         $this->assertFalse($recipient->isFriendWith($sender));
-
+        
         //fr has been delete
         $this->assertCount(0, $recipient->getFriendRequests());
         $this->assertCount(1, $sender->getDeniedFriendships());
     }
-
+    
     /** @test */
-    public function user_can_block_another_user(){
-        $sender = createUser();
+    public function user_can_block_another_user()
+    {
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         $sender->blockFriend($recipient);
-
+        
         $this->assertTrue($recipient->isBlockedBy($sender));
         $this->assertTrue($sender->hasBlocked($recipient));
         //sender is not blocked by receipient
         $this->assertFalse($sender->isBlockedBy($recipient));
         $this->assertFalse($recipient->hasBlocked($sender));
     }
-
+    
     /** @test */
-    public function user_can_unblock_a_blocked_user(){
-        $sender = createUser();
+    public function user_can_unblock_a_blocked_user()
+    {
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         $sender->blockFriend($recipient);
         $sender->unblockFriend($recipient);
-
+        
         $this->assertFalse($recipient->isBlockedBy($sender));
         $this->assertFalse($sender->hasBlocked($recipient));
     }
-
+    
     /** @test */
-    public function user_can_send_friend_request_to_user_who_is_blocked(){
-        $sender = createUser();
+    public function user_can_send_friend_request_to_user_who_is_blocked()
+    {
+        $sender    = createUser();
         $recipient = createUser();
-
+        
         $sender->blockFriend($recipient);
         $sender->befriend($recipient);
         $sender->befriend($recipient);
-
+        
         $this->assertCount(1, $recipient->getFriendRequests());
     }
-
+    
     /** @test */
-    public function it_returns_all_user_friendships(){
-        $sender = createUser();
+    public function it_returns_all_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $this->assertCount(3, $sender->getAllFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_accepted_user_friendships_number(){
-        $sender = createUser();
+    public function it_returns_accepted_user_friendships_number()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $this->assertEquals(2, $sender->getFriendsCount());
     }
-
+    
     /** @test */
-    public function it_returns_accepted_user_friendships(){
-        $sender = createUser();
+    public function it_returns_accepted_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $this->assertCount(2, $sender->getAcceptedFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_only_accepted_user_friendships(){
-        $sender = createUser();
+    public function it_returns_only_accepted_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 4);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $this->assertCount(2, $sender->getAcceptedFriendships());
-
+        
         $this->assertCount(1, $recipients[0]->getAcceptedFriendships());
         $this->assertCount(1, $recipients[1]->getAcceptedFriendships());
         $this->assertCount(0, $recipients[2]->getAcceptedFriendships());
         $this->assertCount(0, $recipients[3]->getAcceptedFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_pending_user_friendships(){
-        $sender = createUser();
+    public function it_returns_pending_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $this->assertCount(2, $sender->getPendingFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_denied_user_friendships(){
-        $sender = createUser();
+    public function it_returns_denied_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $this->assertCount(1, $sender->getDeniedFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_blocked_user_friendships(){
-        $sender = createUser();
+    public function it_returns_blocked_user_friendships()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 3);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->blockFriend($sender);
         $this->assertCount(1, $sender->getBlockedFriendships());
     }
-
+    
     /** @test */
-    public function it_returns_user_friends(){
-        $sender = createUser();
+    public function it_returns_user_friends()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 4);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
-
+        
         $this->assertCount(2, $sender->getFriends());
         $this->assertCount(1, $recipients[1]->getFriends());
         $this->assertCount(0, $recipients[2]->getFriends());
         $this->assertCount(0, $recipients[3]->getFriends());
-
+        
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }
-
+    
     /** @test */
-    public function it_returns_user_friends_per_page(){
-        $sender = createUser();
+    public function it_returns_user_friends_per_page()
+    {
+        $sender     = createUser();
         $recipients = createUser([], 6);
-
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
         }
-
+        
         $recipients[0]->acceptFriendRequest($sender);
         $recipients[1]->acceptFriendRequest($sender);
         $recipients[2]->denyFriendRequest($sender);
         $recipients[3]->acceptFriendRequest($sender);
         $recipients[4]->acceptFriendRequest($sender);
-
-
+        
+        
         $this->assertCount(2, $sender->getFriends(2));
         $this->assertCount(4, $sender->getFriends(0));
         $this->assertCount(4, $sender->getFriends(10));
         $this->assertCount(1, $recipients[1]->getFriends());
         $this->assertCount(0, $recipients[2]->getFriends());
         $this->assertCount(0, $recipients[5]->getFriends(2));
-
+        
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriends());
     }
-
-    /*
-     * Test User Personal Friend Groups
-    */
-
+    
     /** @test */
-    public function add_friend_to_group() {
-
-        $sender    = createUser();
-        $recipient = createUser();
-        $stranger  = createUser();
-
-        $sender->befriend($recipient);
-        $recipient->acceptFriendRequest($sender);
-
-        $this->assertTrue((boolean)$recipient->groupFriend($sender, 'acquaintances'));
-        $this->assertTrue((boolean)$sender->groupFriend($recipient, 'family'));
-
-        $this->assertFalse((boolean)$sender->groupFriend($recipient, 'family'));
-        $this->assertFalse((boolean)$stranger->groupFriend($recipient, 'acquaintances'));
-
-
-    }
-
-    /** @test */
-    public function add_stranger_to_group() {
-
-        $sender    = createUser();
-        $stranger  = createUser();
-
-        $this->assertFalse((boolean)$sender->groupFriend($stranger, 'family'));
-
-    }
-
-    /** @test */
-    public function remove_friend_from_group() {
-
-        $sender    = createUser();
-        $recipient = createUser();
-
-        $sender->befriend($recipient);
-        $recipient->acceptFriendRequest($sender);
-
-        $recipient->groupFriend($sender, 'acquaintances');
-
-        $sender->groupFriend($recipient, 'family');
-        $sender->groupFriend($recipient, 'acquaintances');
-
-        $this->assertEquals(1, $recipient->ungroupFriend($sender));
-        $this->assertEquals(1, $sender->ungroupFriend($recipient, 'family'));
-
-    }
-
-    /** @test */
-    public function get_friends_by_group() {
-
+    public function it_returns_user_friends_of_friends()
+    {
         $sender     = createUser();
-        $recipients = createUser([], 10);
-
-        foreach ($recipients as $key => $recipient) {
-
-            $sender->befriend($recipient);
-            $recipient->acceptFriendRequest($sender);
-
-            if ($key % 2 === 0) {
-                $sender->groupFriend($recipient, 'family');
-            }
-
-        }
-
-        $this->assertCount(5, $sender->getFriends(0, 'family'));
-        $this->assertCount(10, $sender->getFriends());
-
-    }
-
-    /** @test */
-    public function it_returns_user_friends_of_friends(){
-        $sender = createUser();
         $recipients = createUser([], 2);
-        $fofs = createUser([], 5)->chunk(3);
-
+        $fofs       = createUser([], 5)->chunk(3);
+        
         foreach ($recipients as $recipient) {
             $sender->befriend($recipient);
             $recipient->acceptFriendRequest($sender);
-
+            
             //add some friends to each recipient too
             foreach ($fofs->shift() as $fof) {
                 $recipient->befriend($fof);
                 $fof->acceptFriendRequest($recipient);
             }
         }
-
+        
         $this->assertCount(2, $sender->getFriends());
         $this->assertCount(4, $recipients[0]->getFriends());
         $this->assertCount(3, $recipients[1]->getFriends());
-
+        
         $this->assertCount(5, $sender->getFriendsOfFriends());
-
+        
         $this->containsOnlyInstancesOf(\App\User::class, $sender->getFriendsOfFriends());
     }
-
-
+    
+    
 }

--- a/tests/config/friendships.php
+++ b/tests/config/friendships.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    'tables' => [
+        'fr_pivot' => 'friendships',
+        'fr_groups_pivot' => 'user_friendship_groups'
+    ],
+
+    'groups' => [
+        'close_friends' => 0,
+        'acquaintances' => 1
+    ]
+
+];

--- a/tests/config/friendships.php
+++ b/tests/config/friendships.php
@@ -8,8 +8,9 @@ return [
     ],
 
     'groups' => [
-        'close_friends' => 0,
-        'acquaintances' => 1
+        'acquaintances' => 0,
+        'close_friends' => 1,
+        'family' => 2
     ]
 
 ];


### PR DESCRIPTION
User can group/ungroup his/her friends with new methods groupFriend & ungroupFriend.
Personal groups support added to getAllFriendships, getAcceptedFriendships, getFriendsCount, getFriends methods. 