### PR TITLE
Support for Laravel 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ install:
   - COMPOSER_DISCARD_CHANGES=1 composer install --dev --prefer-source --no-interaction
 
 before_script:
+  - mysql -u root -e 'set global innodb_large_prefix=1;'
+  - mysql -u root -e 'set global innodb_file_format="Barracuda";'
+  - mysql -u root -e 'set global innodb_file_format_max="Barracuda";'
+  - mysql -u root -e 'set global innodb_file_per_table=true;'
   - mysql -e 'create database friendships_test;'
   - cp src/database/migrations/create_friendships_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053825_create_friendships_table.php
   - yes | cp src/database/migrations/create_friendships_groups_table.php vendor/laravel/laravel/database/migrations/2015_11_19_053826_create_friendships_groups_table.php
@@ -30,6 +34,7 @@ before_script:
   - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
   - cd vendor/laravel/laravel
   - composer update --dev --prefer-source --no-interaction
+  - perl -pi -w -e "s/'engine' => null,/'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',/g;" config/database.php
   - php artisan migrate
   - cd -
 

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
             "Hootlex\\Friendships\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../vendor/laravel/laravel/bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/FriendshipsEventsTest.php
+++ b/tests/FriendshipsEventsTest.php
@@ -1,8 +1,12 @@
 <?php
 
+namespace Tests;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
+use Mockery;
 
 class FriendshipsEventsTest extends TestCase
 {

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/FriendshipsTest.php
+++ b/tests/FriendshipsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests;
+
+require __DIR__.'/helpers.php';
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -5,8 +5,12 @@
  * @param array $overrides
  * @param int   $amount
  *
- * @return \App\User
+ * @return \Illuminate\Database\Eloquent\Collection|\App\User[]|\App\User
  */
 function createUser($overrides = [], $amount = 1){
-    return factory(\App\User::class, $amount)->create($overrides);
+    $users = factory(\App\User::class, $amount)->create($overrides);
+    if (count($users) == 1) {
+        return $users->first();
+    }
+    return $users;
 }


### PR DESCRIPTION
- [x] Fix tests (New structure/Namespace with Laravel 5.4)
- [x] Fix error with Laravel 5.4 and utf8mb4. 
   Solutions:
      1. ~~Use MySQL v5.7.7 or higher for the build~~
      2. ~~Set defaultStringLength on Schema~~
      3. Change innodb configuration and set engine to ROW_FORMAT=DYNAMIC

