### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This package gives Eloquent models the ability to manage their friendships.
 You can easily design a Facebook like Friend System.
 
-##Models can:
+## Models can:
 - Send Friend Requests
 - Accept Friend Requests
 - Deny Friend Requests


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
