### PR TITLE
Replace Event alias by complete namespace

### DIFF
--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -6,7 +6,7 @@ use Hootlex\Friendships\Models\Friendship;
 use Hootlex\Friendships\Models\FriendFriendshipGroups;
 use Hootlex\Friendships\Status;
 use Illuminate\Database\Eloquent\Model;
-use Event;
+use Illuminate\Support\Facades\Event;
 
 /**
  * Class Friendable


### PR DESCRIPTION
Hello there!

First of all, awesome package here, made my day when I realise I didn't have to code all that myself. Cheers for that!

Error:
```Call to undefined method Event::fire()```

Using facade aliases can cause issue while loading the package, using the complete namespace instead prevent from having issue.

Moreover if the laravel project config renamed the alias for whatever reason I think it might break it.

