### PR TITLE
Allow models to get friendships requested by others

### DIFF
--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -507,6 +507,14 @@ trait Friendable
     /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
+    public function friendshipsReceived()
+    {
+        return $this->morphMany(Friendship::class, 'recipient');
+    }
+    
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function groups()
     {
         return $this->morphMany(FriendFriendshipGroups::class, 'friend');


### PR DESCRIPTION
Models can now call $this->friendshipsReceived() to get a query with friendships that were requested by others.
For example this allows to exclude all users that are either blocked by or have blocked our authenticated user from the query:
App\User::whereDoesntHave('friendshipsReceived', function ($query) {
            $query->where('status', 3);
        })->whereDoesntHave('friends', function ($query) {
            $query->where('status', 3);
        });