### PR TITLE
Fix bug with whereGroup scope

### DIFF
--- a/src/Models/Friendship.php
+++ b/src/Models/Friendship.php
@@ -97,9 +97,9 @@ class Friendship extends Model
         $friendsPivotTable  = config('friendships.tables.fr_pivot');
         $groupsAvailable = config('friendships.groups', []);
 
-        if ('' !== $groupSlug && isset($groupsAvailable[$groupSlug])) {
+        if ('' !== $groupSlug) {
 
-            $groupId = $groupsAvailable[$groupSlug];
+            $groupId = isset($groupsAvailable[$groupSlug]) ? $groupsAvailable[$groupSlug] : -1;
 
             $query->join($groupsPivotTable, function ($join) use ($groupsPivotTable, $friendsPivotTable, $groupId, $model) {
                 $join->on($groupsPivotTable . '.friendship_id', '=', $friendsPivotTable . '.id')

--- a/tests/FriendshipsGroupsTest.php
+++ b/tests/FriendshipsGroupsTest.php
@@ -155,7 +155,7 @@ class FriendshipsGroupsTest extends TestCase
         $this->assertCount(3, $sender->getAllFriendships('acquaintances'));
         $this->assertCount(1, $sender->getAllFriendships('family'));
         $this->assertCount(0, $sender->getAllFriendships('close_friends'));
-        $this->assertCount(5, $sender->getAllFriendships('whatever'));
+        $this->assertCount(0, $sender->getAllFriendships('whatever'));
     }
 
 


### PR DESCRIPTION
Where if the group does not exist, the group query is ignored (all results are returned instead of none).