### PR TITLE
Adding Query to get Pending Friend Requests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ $user->getAllFriendships();
 $user->getPendingFriendships();
 ```
 
+#### Get a list of pending Requests
+```php
+$user->getPendingRequests();
+```
+
 #### Get a list of accepted Friendships
 ```php
 $user->getAcceptedFriendships();

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -248,6 +248,17 @@ trait Friendable
      * @param string $groupSlug
      *
      */
+    public function getPendingRequests($groupSlug = '')
+    {
+        return $this->findPendingRequests(Status::PENDING, $groupSlug)->get();
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection|Friendship[]
+     *
+     * @param string $groupSlug
+     *
+     */
     public function getAcceptedFriendships($groupSlug = '')
     {
         return $this->findFriendships(Status::ACCEPTED, $groupSlug)->get();
@@ -411,6 +422,29 @@ trait Friendable
                 $q->whereSender($this);
             })->orWhere(function ($q) {
                 $q->whereRecipient($this);
+            });
+        })->whereGroup($this, $groupSlug);
+
+        //if $status is passed, add where clause
+        if (!is_null($status)) {
+            $query->where('status', $status);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param $status
+     * @param string $groupSlug
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function findPendingRequests($status = null, $groupSlug = '')
+    {
+
+        $query = Friendship::where(function ($query) {
+            $query->where(function ($q) {
+                $q->whereSender($this);
             });
         })->whereGroup($this, $groupSlug);
 


### PR DESCRIPTION
This PR helps users get the list of all pending requests sent by that particular user.  While using `getPendingFriendships` did work, the result contained all the pending friendships queries for that user regardless of whether the user was the sender or recipient of the friend request. This PR helps clean that bit.

This PR fixes #113 