### PR TITLE
Support for Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - cd vendor/laravel/laravel
   - composer update --dev --prefer-source --no-interaction
   - perl -pi -w -e "s/'engine' => null,/'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',/g;" config/database.php
-  - php artisan migrate
+  - php artisan migrate --force
   - cd -
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 php:
   - 5.6
   - 7.0
+  - 7.2
 
 addons:
     code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ services:
   - mysql
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
   - 7.2
 
 addons:
@@ -21,7 +20,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - COMPOSER_DISCARD_CHANGES=1 composer install --prefer-source --no-interaction
+  - COMPOSER_DISCARD_CHANGES=1 composer install --dev --prefer-source --no-interaction
 
 before_script:
   - mysql -u root -e 'set global innodb_large_prefix=1;'
@@ -34,7 +33,7 @@ before_script:
   - yes | cp tests/config/friendships.php vendor/laravel/laravel/config/friendships.php
   - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
   - cd vendor/laravel/laravel
-  - composer update --prefer-source --no-interaction
+  - composer update --dev --prefer-source --no-interaction
   - perl -pi -w -e "s/'engine' => null,/'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',/g;" config/database.php
   - php artisan migrate
   - cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - COMPOSER_DISCARD_CHANGES=1 composer install --dev --prefer-source --no-interaction
+  - COMPOSER_DISCARD_CHANGES=1 composer install --prefer-source --no-interaction
 
 before_script:
   - mysql -u root -e 'set global innodb_large_prefix=1;'
@@ -34,7 +34,7 @@ before_script:
   - yes | cp tests/config/friendships.php vendor/laravel/laravel/config/friendships.php
   - yes | cp tests/Stub_User.php vendor/laravel/laravel/app/User.php
   - cd vendor/laravel/laravel
-  - composer update --dev --prefer-source --no-interaction
+  - composer update --prefer-source --no-interaction
   - perl -pi -w -e "s/'engine' => null,/'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',/g;" config/database.php
   - php artisan migrate
   - cd -

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.2",
+        "nunomaduro/collision": "3.*",
         "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "5.*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "5.*",
+        "phpunit/phpunit": "^7.0"
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "5.*",
         "codeclimate/php-test-reporter": "^0.3.2",

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,9 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "beyondcode/laravel-dump-server": "^1.2",
-        "nunomaduro/collision": "3.*",
         "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
-        "laravel/laravel": "5.*",
+        "laravel/laravel": "~5.6.0|~5.7.0|~5.8.0",
         "codeclimate/php-test-reporter": "^0.3.2",
         "mockery/mockery": "^0.9.5",
         "doctrine/dbal": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
+        "beyondcode/laravel-dump-server": "^1.2",
+        "nunomaduro/collision": "3.*",
         "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "~5.6.0|~5.7.0|~5.8.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/collision": "3.*",
         "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
-        "laravel/laravel": "~5.6.0|~5.7.0|~5.8.0",
+        "laravel/laravel": "~5.6",
         "codeclimate/php-test-reporter": "^0.3.2",
         "mockery/mockery": "^0.9.5",
         "doctrine/dbal": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
+        "beyondcode/laravel-dump-server": "^1.2",
         "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "5.*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "5.*",
         "codeclimate/php-test-reporter": "^0.3.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit" : "5.*",
         "fzaninotto/faker": "~1.4",
         "laravel/laravel": "5.*",
         "codeclimate/php-test-reporter": "^0.3.2",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.1.3"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.2",

--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -32,7 +32,7 @@ trait Friendable
 
         $this->friends()->save($friendship);
       
-        Event::fire('friendships.sent', [$this, $recipient]);
+        Event::dispatch('friendships.sent', [$this, $recipient]);
 
         return $friendship;
 
@@ -47,7 +47,7 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->delete();
 
-        Event::fire('friendships.cancelled', [$this, $recipient]);
+        Event::dispatch('friendships.cancelled', [$this, $recipient]);
 
         return $deleted;
     }
@@ -93,7 +93,7 @@ trait Friendable
             'status' => Status::ACCEPTED,
         ]);
 
-        Event::fire('friendships.accepted', [$this, $recipient]);
+        Event::dispatch('friendships.accepted', [$this, $recipient]);
       
         return $updated;
     }
@@ -109,7 +109,7 @@ trait Friendable
             'status' => Status::DENIED,
         ]);
 
-        Event::fire('friendships.denied', [$this, $recipient]);
+        Event::dispatch('friendships.denied', [$this, $recipient]);
       
         return $updated;
     }
@@ -191,7 +191,7 @@ trait Friendable
       
         $this->friends()->save($friendship);
 
-        Event::fire('friendships.blocked', [$this, $recipient]);
+        Event::dispatch('friendships.blocked', [$this, $recipient]);
 
         return $friendship;
     }
@@ -205,7 +205,7 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->whereSender($this)->delete();
 
-        Event::fire('friendships.unblocked', [$this, $recipient]);
+        Event::dispatch('friendships.unblocked', [$this, $recipient]);
       
         return $deleted;
     }

--- a/tests/FriendshipsEventsTest.php
+++ b/tests/FriendshipsEventsTest.php
@@ -12,7 +12,7 @@ class FriendshipsEventsTest extends TestCase
 {
     // use DatabaseTransactions;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/FriendshipsEventsTest.php
+++ b/tests/FriendshipsEventsTest.php
@@ -20,7 +20,7 @@ class FriendshipsEventsTest extends TestCase
         $this->recipient = createUser();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/FriendshipsEventsTest.php
+++ b/tests/FriendshipsEventsTest.php
@@ -11,34 +11,34 @@ use Mockery;
 class FriendshipsEventsTest extends TestCase
 {
     // use DatabaseTransactions;
-    
+
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->sender    = createUser();
         $this->recipient = createUser();
     }
-  
+
     public function tearDown()
     {
         Mockery::close();
     }
-  
+
     /** @test */
     public function friend_request_is_sent()
     {
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.sent', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.sent', Mockery::any()]);
+
         $this->sender->befriend($this->recipient);
     }
-  
+
     /** @test */
     public function friend_request_is_accepted()
     {
         $this->sender->befriend($this->recipient);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.accepted', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.accepted', Mockery::any()]);
+
         $this->recipient->acceptFriendRequest($this->sender);
     }
 
@@ -46,8 +46,8 @@ class FriendshipsEventsTest extends TestCase
     public function friend_request_is_denied()
     {
         $this->sender->befriend($this->recipient);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.denied', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.denied', Mockery::any()]);
+
         $this->recipient->denyFriendRequest($this->sender);
     }
 
@@ -56,29 +56,29 @@ class FriendshipsEventsTest extends TestCase
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.blocked', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.blocked', Mockery::any()]);
+
         $this->recipient->blockFriend($this->sender);
     }
-  
+
     /** @test */
     public function friend_is_unblocked()
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
         $this->recipient->blockFriend($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.unblocked', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.unblocked', Mockery::any()]);
+
         $this->recipient->unblockFriend($this->sender);
     }
-  
+
     /** @test */
     public function friendship_is_cancelled()
     {
         $this->sender->befriend($this->recipient);
         $this->recipient->acceptFriendRequest($this->sender);
-        Event::shouldReceive('fire')->once()->withArgs(['friendships.cancelled', Mockery::any()]);
-        
+        Event::shouldReceive('dispatch')->once()->withArgs(['friendships.cancelled', Mockery::any()]);
+
         $this->recipient->unfriend($this->sender);
     }
 }


### PR DESCRIPTION
Already made a PR on MoeCasts fork, but it might be quicker to just make a new PR here.

You can delete this PR if another fix is merged.

Next version should probably be 1.1, since we drop support for previous php version.