### PR TITLE
convert fire to dispatch

### DIFF
--- a/src/Traits/Friendable.php
+++ b/src/Traits/Friendable.php
@@ -32,7 +32,7 @@ trait Friendable
 
         $this->friends()->save($friendship);
       
-        Event::fire('friendships.sent', [$this, $recipient]);
+        Event::dispatch('friendships.sent', [$this, $recipient]);
 
         return $friendship;
 
@@ -47,7 +47,7 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->delete();
 
-        Event::fire('friendships.cancelled', [$this, $recipient]);
+        Event::dispatch('friendships.cancelled', [$this, $recipient]);
 
         return $deleted;
     }
@@ -93,7 +93,7 @@ trait Friendable
             'status' => Status::ACCEPTED,
         ]);
 
-        Event::fire('friendships.accepted', [$this, $recipient]);
+        Event::dispatch('friendships.accepted', [$this, $recipient]);
       
         return $updated;
     }
@@ -109,7 +109,7 @@ trait Friendable
             'status' => Status::DENIED,
         ]);
 
-        Event::fire('friendships.denied', [$this, $recipient]);
+        Event::dispatch('friendships.denied', [$this, $recipient]);
       
         return $updated;
     }
@@ -191,7 +191,7 @@ trait Friendable
       
         $this->friends()->save($friendship);
 
-        Event::fire('friendships.blocked', [$this, $recipient]);
+        Event::dispatch('friendships.blocked', [$this, $recipient]);
 
         return $friendship;
     }
@@ -205,7 +205,7 @@ trait Friendable
     {
         $deleted = $this->findFriendship($recipient)->whereSender($this)->delete();
 
-        Event::fire('friendships.unblocked', [$this, $recipient]);
+        Event::dispatch('friendships.unblocked', [$this, $recipient]);
       
         return $deleted;
     }


### PR DESCRIPTION
Updated Friendable trait to use dispatch in place of the fire method.  Tested working on befriend(), acceptFriendRequest(), and getFriends().